### PR TITLE
Set STATIC_URL to https://www.mozilla.org/media/ in prod

### DIFF
--- a/frankfurt/bedrock-prod/deploy.yaml
+++ b/frankfurt/bedrock-prod/deploy.yaml
@@ -152,6 +152,8 @@ spec:
             secretKeyRef:
               key: sentry-dsn
               name: bedrock-prod-secrets
+        - name: STATIC_URL
+          value: "https://www.mozilla.org/media/"
         - name: STD_SMS_COUNTRIES_DESKTOP
           value: US,DE,FR
         - name: STD_SMS_COUNTRIES_WHATSNEW50

--- a/iowa-a/bedrock-prod/deploy.yaml
+++ b/iowa-a/bedrock-prod/deploy.yaml
@@ -152,6 +152,8 @@ spec:
             secretKeyRef:
               key: sentry-dsn
               name: bedrock-prod-secrets
+        - name: STATIC_URL
+          value: "https://www.mozilla.org/media/"
         - name: STD_SMS_COUNTRIES_DESKTOP
           value: US,DE,FR
         - name: STD_SMS_COUNTRIES_WHATSNEW50


### PR DESCRIPTION
We shouldn't need to adjust the CSP header in prod as it already includes *.mozilla.org:

```
$ curl -Is www.mozilla.org | grep Content-Security
```

> Content-Security-Policy: script-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com tagmanager.google.com www.youtube.com s.ytimg.com; img-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com data: mozilla.org www.googletagmanager.com www.google-analytics.com adservice.google.com adservice.google.de adservice.google.dk creativecommons.org ad.doubleclick.net; default-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com; frame-src www.googletagmanager.com www.google-analytics.com www.youtube-nocookie.com trackertest.org www.surveygizmo.com accounts.firefox.com accounts.firefox.com.cn www.youtube.com; style-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com 'unsafe-inline'; connect-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com www.googletagmanager.com www.google-analytics.com https://accounts.firefox.com/ https://accounts.firefox.com.cn/; child-src www.googletagmanager.com www.google-analytics.com www.youtube-nocookie.com trackertest.org www.surveygizmo.com accounts.firefox.com accounts.firefox.com.cn www.youtube.com