### PR TITLE
Increase maxSurge to 5 in frankfurt & iowa-a prod

### DIFF
--- a/frankfurt/bedrock-prod/deploy.yaml
+++ b/frankfurt/bedrock-prod/deploy.yaml
@@ -14,7 +14,7 @@ spec:
       type: web
   strategy:
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 5
       maxUnavailable: 0
     type: RollingUpdate
   template:

--- a/iowa-a/bedrock-prod/deploy.yaml
+++ b/iowa-a/bedrock-prod/deploy.yaml
@@ -14,7 +14,7 @@ spec:
       type: web
   strategy:
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 5
       maxUnavailable: 0
     type: RollingUpdate
   template:


### PR DESCRIPTION
This should speed up prod deploys a bit. See also https://github.com/mozmeao/www-config/commit/e8737213864d785bf7370be40cd893ae7391732f where this was applied in dev & stage. 