### PR TITLE
Add oregon-b/bedrock-test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,22 @@ stages:
     DEPLOYMENT: frankfurt/bedrock-prod
     KUBECONFIG: /home/gitlab-runner/.kube/frankfurt.kubeconfig
 
+.oregon-b-test:
+  only:
+    changes:
+      - "oregon-b/bedrock-test/*"
+    refs:
+      - master
+      - bedrock-test
+    variables:
+      - $CI_PIPELINE_SOURCE == "push"
+  tags:
+    - oregon-b-shell
+  variables:
+    BASE_URL: https://bedrock-test.moz.works
+    DEPLOYMENT: oregon-b/bedrock-test
+    KUBECONFIG: /home/gitlab-runner/.kube/oregon-b.kubeconfig
+
 .prod-iowa-a:
   only:
     changes:
@@ -191,6 +207,36 @@ dev-test-headless:
 dev-test-ie:
   extends:
     - .dev
+    - .test-ie
+
+oregon-b-test-deploy:
+  extends:
+    - .deploy
+    - .oregon-b-test
+
+oregon-b-test-chrome:
+  extends:
+    - .oregon-b-test
+    - .test-chrome
+
+oregon-b-test-download:
+  extends:
+    - .oregon-b-test
+    - .test-download
+
+oregon-b-test-firefox:
+  extends:
+    - .oregon-b-test
+    - .test-firefox
+
+oregon-b-test-headless:
+  extends:
+    - .oregon-b-test
+    - .test-headless
+
+oregon-b-test-ie:
+  extends:
+    - .oregon-b-test
     - .test-ie
 
 prod-frankfurt-deploy:

--- a/oregon-b/bedrock-test/configmap.yaml
+++ b/oregon-b/bedrock-test/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: bedrock-test-configmap
+    namespace: bedrock-test
+data:
+    NEW_RELIC_APP_NAME: bedrock-test-orgeon-b;bedrock-test
+    # TODO: DEPRECATE DEIS_DOMAIN IN FAVOR OF CLUSTER_NAME
+    DEIS_DOMAIN: gcp.moz.works
+    CLUSTER_NAME: oregon-b

--- a/oregon-b/bedrock-test/deploy.yaml
+++ b/oregon-b/bedrock-test/deploy.yaml
@@ -114,7 +114,7 @@ spec:
           value: django_statsd.clients.normal
         - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
           value: "False"
-        image: mozorg/bedrock:master-1a644a830d66244618921e4c953bb4de64768e77
+        image: mozorg/bedrock:master-8575d4780ab12a893f4833b3974f22e6d32a4d8f
         imagePullPolicy: IfNotPresent
         name: bedrock-test-web
         ports:

--- a/oregon-b/bedrock-test/deploy.yaml
+++ b/oregon-b/bedrock-test/deploy.yaml
@@ -1,0 +1,155 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: bedrock-test
+    type: web
+  name: bedrock-test-web
+  namespace: bedrock-test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: bedrock-test
+      type: web
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: bedrock-test
+        type: web
+      name: bedrock-test-web
+      namespace: bedrock-test
+    spec:
+      containers:
+      - args:
+        - ./bin/run.sh
+        command:
+        - /bin/bash
+        - -c
+        env:
+        - name: ALLOWED_HOSTS
+          value: "*"
+        - name: BASKET_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: basket-api-key
+              name: bedrock-test-secrets
+        - name: BASKET_URL
+          value: https://basket.allizom.org
+        - name: CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: bedrock-test-configmap
+              key: CLUSTER_NAME
+        - name: CSP_DEFAULT_SRC
+          value: "*.allizom.org"
+        - name: CSP_REPORT_ENABLE
+          value: "True"
+        - name: DEBUG
+          value: "False"
+        - name: DEIS_DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              name: bedrock-test-configmap
+              key: DEIS_DOMAIN
+        - name: DEV
+          value: "True"
+        - name: DISABLE_SSL
+          value: "False"
+        - name: ENABLE_CSP_MIDDLEWARE
+          value: "True"
+        - name: ENABLE_HOSTNAME_MIDDLEWARE
+          value: "True"
+        - name: GTM_CONTAINER_ID
+          value: GTM-MW3R8V
+        - name: HTTPS
+          value: "on"
+        - name: L10N_CRON
+          value: "True"
+        - name: LOGLEVEL
+          value: info
+        - name: MOFO_SECURITY_ADVISORIES_BRANCH
+          value: testing
+        - name: MOFO_SECURITY_ADVISORIES_PATH
+          value: /tmp/mofo_security_advisories
+        - name: NEW_RELIC_APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: bedrock-test-configmap
+              key: NEW_RELIC_APP_NAME
+        - name: NEW_RELIC_LICENSE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: new-relic-license-key
+              name: bedrock-test-secrets
+        - name: PROD
+          value: "True"
+        - name: RUN_SUPERVISOR
+          value: "True"
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret-key
+              name: bedrock-test-secrets
+        - name: SECURE_BROWSER_XSS_FILTER
+          value: "True"
+        - name: SECURE_HSTS_SECONDS
+          value: "31536000"
+        - name: SECURE_SSL_REDIRECT
+          value: "True"
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              key: sentry-dsn
+              name: bedrock-test-secrets
+        - name: STATIC_URL
+          value: "https://www-dev.allizom.org/media/"
+        - name: STATSD_CLIENT
+          value: django_statsd.clients.normal
+        - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
+          value: "False"
+        image: mozorg/bedrock:master-1a644a830d66244618921e4c953bb4de64768e77
+        imagePullPolicy: IfNotPresent
+        name: bedrock-test-web
+        ports:
+          - containerPort: 8000
+        livenessProbe:
+          failureThreshold: 4
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+          httpGet:
+            path: /healthz/
+            scheme: HTTP
+            port: 8000
+        readinessProbe:
+          failureThreshold: 1
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+          httpGet:
+            path: /readiness/
+            scheme: HTTP
+            port: 8000
+        resources:
+          limits:
+            cpu: 1500m
+            memory: 1000Mi
+          requests:
+            cpu: 750m
+            memory: 600Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/oregon-b/bedrock-test/ns.yaml
+++ b/oregon-b/bedrock-test/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bedrock-test

--- a/oregon-b/bedrock-test/svc.yaml
+++ b/oregon-b/bedrock-test/svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: bedrock-test
+  name: bedrock-test-nodeport
+  namespace: bedrock-test
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+    nodePort: 31888
+  selector:
+    app: bedrock-test
+    type: web
+  sessionAffinity: None
+  type: NodePort


### PR DESCRIPTION
This adds a dedicated deployment in oregon-b for integration test purposes. There will be a follow up PR to bedrock that updates this deployment and runs the integration tests on push to the `run-integration-tests` branch of bedrock. See also https://github.com/mozmeao/infra/issues/1185