### PR TITLE
Add retries to deploy & test jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ stages:
     - iowa-c # shell runner with iowa-a.kubeconfig via IAM role
   variables:
     KUBECONFIG: /home/gitlab-runner/.kube/iowa-a.kubeconfig
+  retry: 2
 
 .dev:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,7 @@ stages:
     - .test-shell
   tags:
     - oregon-b-shell
+  retry: 1
 
 .test-chrome:
   extends: .test


### PR DESCRIPTION
- https://docs.gitlab.com/ee/ci/yaml/#retry
- Add `retry: 2` to `.deploy` jobs
- Add `retry: 1` to `.test` jobs

This should reduce the need to retry deploy or test jobs manually, and we can tweak these values and/or override them on a per test basis as desired.