### PR TITLE
Reduce prod pod count

### DIFF
--- a/iowa-a/bedrock-prod/deploy.yaml
+++ b/iowa-a/bedrock-prod/deploy.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: bedrock-prod
 spec:
   progressDeadlineSeconds: 900
-  replicas: 50
+  replicas: 45
   selector:
     matchLabels:
       app: bedrock-prod

--- a/iowa-a/bedrock-prod/hpa.yaml
+++ b/iowa-a/bedrock-prod/hpa.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: bedrock-prod
 spec:
   maxReplicas: 100
-  minReplicas: 50
+  minReplicas: 45
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
It seems like the hpa doesn't typically scale up.
To save resources/money, let's scale down a bit and see if we get more usage per pod.

helps address mozmeao/infra#1292