### PR TITLE
Add local testing via selenium

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - deploy
   - test
 
+variables:
+  SKIP_DRIVER: Remote  # set to SauceLabs to instead only run local selenium
+
 .base-url:
   only:
     variables:
@@ -13,6 +16,11 @@ stages:
     MARK_EXPRESSION: not headless and not download
     TEST_IMAGE: mozmeao/bedrock_test:3c862bfd5acd8b4587a511a8864f771120767968
     PYTEST_PROCESSES: "4"
+
+.default-test-variables-local:
+  extends: .default-test-variables
+  variables:
+    DRIVER: Remote
 
 .deploy:
   script:
@@ -117,12 +125,27 @@ stages:
     - aws
   retry: 1
 
+.test-local:
+  stage: test
+  extends:
+    - .default-test-variables-local
+    - .test-shell
+  tags:
+    - mozmeao
+    - aws
+  after_script:
+    - bin/cleanup_after_functional_tests.sh
+  retry: 1
+
 .test-chrome:
   extends: .test
   variables:
     BROWSER_NAME: chrome
     BROWSER_VERSION: latest
     PLATFORM: Windows 10
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
 
 .test-download:
   extends: .test
@@ -136,6 +159,17 @@ stages:
     BROWSER_NAME: firefox
     BROWSER_VERSION: latest
     PLATFORM: Windows 10
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
+
+.test-firefox-local:
+  extends: .test-local
+  variables:
+    BROWSER_NAME: firefox
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
 
 .test-headless:
   extends: .test
@@ -149,12 +183,18 @@ stages:
     BROWSER_NAME: MicrosoftEdge
     BROWSER_VERSION: latest
     PLATFORM: Windows 10
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
 
 .test-ie:
   extends: .test
   variables:
     BROWSER_NAME: internet explorer
     PLATFORM: Windows 10
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
 
 .test-ie9:
   extends: .test
@@ -163,6 +203,9 @@ stages:
     BROWSER_VERSION: "9.0"
     PLATFORM: Windows 7
     MARK_EXPRESSION: sanity
+  except:
+    variables:
+      - $DRIVER == $SKIP_DRIVER
 
 base-url-test-chrome:
   extends:
@@ -178,6 +221,11 @@ base-url-test-firefox:
   extends:
     - .base-url
     - .test-firefox
+
+base-url-test-firefox-local:
+  extends:
+    - .base-url
+    - .test-firefox-local
 
 base-url-test-headless:
   extends:
@@ -208,6 +256,11 @@ dev-test-firefox:
   extends:
     - .dev
     - .test-firefox
+
+dev-test-firefox-local:
+  extends:
+    - .dev
+    - .test-firefox-local
 
 dev-test-headless:
   extends:
@@ -243,6 +296,11 @@ oregon-b-test-firefox:
   extends:
     - .oregon-b-test
     - .test-firefox
+
+oregon-b-test-firefox-local:
+  extends:
+    - .oregon-b-test
+    - .test-firefox-local
 
 oregon-b-test-headless:
   extends:
@@ -294,6 +352,11 @@ prod-iowa-a-test-firefox:
     - .prod-iowa-a
     - .test-firefox
 
+prod-iowa-a-test-firefox-local:
+  extends:
+    - .prod-iowa-a
+    - .test-firefox-local
+
 prod-iowa-a-test-headless:
   extends:
     - .prod-iowa-a
@@ -328,6 +391,11 @@ stage-test-firefox:
   extends:
     - .stage
     - .test-firefox
+
+stage-test-firefox-local:
+  extends:
+    - .stage
+    - .test-firefox-local
 
 stage-test-headless:
   extends:

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -1,10 +1,42 @@
 #!/bin/bash -ex
 
+if [ "${DRIVER}" = "Remote" ]; then
+  # Start Selenium hub and NUMBER_OF_NODES (default 5) firefox nodes.
+  # Waits until all nodes are ready and then runs tests
+  SELENIUM_VERSION=${DOCKER_SELENIUM_VERSION:-"3.141.59-20200525"}
+  docker pull selenium/hub:${SELENIUM_VERSION}
+  docker pull selenium/node-firefox:${SELENIUM_VERSION}
+  # start selenium grid hub
+  docker run -d --rm -p 4444:4444 \
+    --name bedrock-selenium-hub-${CI_COMMIT_SHA} \
+    selenium/hub:${SELENIUM_VERSION}
+  DOCKER_LINKS=(${DOCKER_LINKS[@]} --link bedrock-selenium-hub-${CI_COMMIT_SHA}:hub)
+  SELENIUM_HOST="hub"
+  SELENIUM_PORT="4444"
+
+  # start selenium grid nodes
+  for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`; do
+    docker run -d --rm --shm-size 2g \
+      --name bedrock-selenium-node-${NODE_NUMBER}-${CI_COMMIT_SHA} \
+      ${DOCKER_LINKS[@]} \
+      selenium/node-firefox:${SELENIUM_VERSION}
+    while ! ${SELENIUM_READY}; do
+      IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' bedrock-selenium-node-${NODE_NUMBER}-${CI_COMMIT_SHA}`
+      CMD="docker run --rm --link bedrock-selenium-hub-${CI_COMMIT_SHA}:hub tutum/curl curl http://hub:4444/grid/api/proxy/?id=http://${IP}:5555 | grep 'proxy found'"
+      if eval ${CMD}; then SELENIUM_READY=true; fi
+    done
+  done
+fi
+
 docker pull ${TEST_IMAGE:=mozmeao/bedrock_test}
 docker run --rm \
+    ${DOCKER_LINKS[@]} \
     -e "DRIVER=${DRIVER}" \
     -e "SAUCELABS_USERNAME=${SAUCELABS_USERNAME}" \
     -e "SAUCELABS_API_KEY=${SAUCELABS_API_KEY}" \
+    -e "SELENIUM_HOST=${SELENIUM_HOST}" \
+    -e "SELENIUM_PORT=${SELENIUM_PORT}" \
+    -e "SELENIUM_VERSION=${SELENIUM_VERSION}" \
     -e "BROWSER_NAME=${BROWSER_NAME}" \
     -e "BROWSER_VERSION=${BROWSER_VERSION}" \
     -e "PLATFORM=${PLATFORM}" \

--- a/bin/cleanup_after_functional_tests.sh
+++ b/bin/cleanup_after_functional_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $BIN_DIR/set_git_env_vars.sh
+
+docker stop bedrock-code-${CI_COMMIT_SHA}
+
+for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`;
+do
+    docker stop bedrock-selenium-node-${NODE_NUMBER}-${CI_COMMIT_SHA}
+done;
+
+docker stop bedrock-selenium-hub-${CI_COMMIT_SHA}
+
+# always report success
+exit 0


### PR DESCRIPTION
This adds jobs to run selenium tests in a local cluster running on the CI runner. It adds a global variable in the CI config called `SKIP_DRIVER`, which we'll set to `Remote` initially, which will cause it to not actually start the local selenium and run those tests. But it can be changed to `SauceLabs` to only run the non-sauce tests including the local selenium ones. This means we can merge this and use the switch whenever we need it. I'd love to hear your thoughts on the matter @alexgibson .