### PR TITLE
Disable download tests for dev deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -247,11 +247,6 @@ dev-test-chrome:
     - .dev
     - .test-chrome
 
-dev-test-download:
-  extends:
-    - .dev
-    - .test-download
-
 dev-test-firefox:
   extends:
     - .dev


### PR DESCRIPTION
Following up on the work in https://github.com/mozilla/bedrock/pull/9210 this disables the download tests for dev deployments. The reasoning is that those run a lot and it is overkill to test all of these links (around 4700 at time of writing) for every merge to the main branch.

This leaves the download tests running for stage and prod deployments as well as the ones you can manually run and the run-integration-tests branch.