### PR TITLE
Expire dotenv artifacts in a week.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,8 +98,6 @@ deploy-prod-iowa:
     - mozmeao
     - aws
   after_script:
-    - docker cp "bedrock-${CI_JOB_ID}:/app/tests/results" "results-${CI_JOB_ID}"
-    - docker rm "bedrock-${CI_JOB_ID}"
     - bin/cleanup_after_functional_tests.sh
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,7 @@ stages:
     when:
       on_success
     expire_in:
-      15 mins
-
+      1 week
 .iowa:
   tags:
     - iowa-c

--- a/bin/cleanup_after_functional_tests.sh
+++ b/bin/cleanup_after_functional_tests.sh
@@ -7,6 +7,12 @@ then
     exit 0;
 fi
 
+# Copy artifacts from container to host to make them available for upload to GitLab
+docker cp "bedrock-${CI_JOB_ID}:/app/tests/results" "results-${CI_JOB_ID}"
+
+# Now that we copied artifact, remove container.
+docker rm "bedrock-${CI_JOB_ID}"
+
 if [ "${DRIVER}" = "Remote" ]; then
     docker-compose \
         -p "selenium-hub-${CI_JOB_ID}" \

--- a/bin/cleanup_after_functional_tests.sh
+++ b/bin/cleanup_after_functional_tests.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -x
 
+if [ -z "${BASE_URL:-}" ];
+then
+    # No BASE_URL set, thus no tests run. Nothing to cleanup
+    exit 0;
+fi
+
 if [ "${DRIVER}" = "Remote" ]; then
     docker-compose \
         -p "selenium-hub-${CI_JOB_ID}" \


### PR DESCRIPTION
So we can still run manual saucelabs jobs after a few days.