### PR TITLE
Increasing bedrock test resources increase

### DIFF
--- a/iowa-a/bedrock-test/deploy.yaml
+++ b/iowa-a/bedrock-test/deploy.yaml
@@ -144,11 +144,11 @@ spec:
             port: 8000
         resources:
           limits:
-            cpu: 1000m
-            memory: 1500Mi
+            cpu: 1500m
+            memory: 1750Mi
           requests:
-            cpu: 750m
-            memory: 1250Mi
+            cpu: 1250m
+            memory: 1500Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
Giving more resources to the test deployment, because we're observing more some sysexits