### PR TITLE
Removing gevent from non prod environments

### DIFF
--- a/iowa-a/bedrock-dev/deploy.yaml
+++ b/iowa-a/bedrock-dev/deploy.yaml
@@ -107,8 +107,6 @@ spec:
           value: "True"
         - name: GTM_CONTAINER_ID
           value: GTM-MW3R8V
-        - name: GUNICORN_WORKER_CLASS
-          value: gevent
         - name: HTTPS
           value: "on"
         - name: L10N_CRON

--- a/iowa-a/bedrock-stage/deploy.yaml
+++ b/iowa-a/bedrock-stage/deploy.yaml
@@ -122,8 +122,6 @@ spec:
               name: bedrock-stage-secrets
         - name: GTM_CONTAINER_ID
           value: GTM-MW3R8V
-        - name: GUNICORN_WORKER_CLASS
-          value: gevent
         - name: HTTPS
           value: "on"
         - name: L10N_CRON

--- a/iowa-a/bedrock-test/deploy.yaml
+++ b/iowa-a/bedrock-test/deploy.yaml
@@ -72,8 +72,6 @@ spec:
           value: "True"
         - name: GTM_CONTAINER_ID
           value: GTM-MW3R8V
-        - name: GUNICORN_WORKER_CLASS
-          value: gevent
         - name: HTTPS
           value: "on"
         - name: L10N_CRON
@@ -118,7 +116,7 @@ spec:
         - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
           value: "False"
         - name: WEB_CONCURRENCY
-          value: "8"
+          value: "6"
         image: mozmeao/bedrock:a7809394130cb6d7f17a025f13e14ad430c228b7
         imagePullPolicy: IfNotPresent
         name: bedrock-test-web


### PR DESCRIPTION
this worker type was an experiement that we ended up moving to a canary deploy
and then the canary deploy told us we shouldn't promote
but it seems we didn't flow that back to the canary deploy