### PR TITLE
turning off vpa autoupdating

### DIFF
--- a/iowa-a/bedrock-dev/vpa.yaml
+++ b/iowa-a/bedrock-dev/vpa.yaml
@@ -22,7 +22,7 @@ spec:
     kind:       Deployment
     name:       bedrock-dev-clock
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -35,4 +35,4 @@ spec:
     kind:       DaemonSet
     name:       bedrock-dev-data
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"

--- a/iowa-a/bedrock-prod/vpa.yaml
+++ b/iowa-a/bedrock-prod/vpa.yaml
@@ -22,7 +22,7 @@ spec:
     kind:       Deployment
     name:       bedrock-prod-clock
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -35,7 +35,7 @@ spec:
     kind:       DaemonSet
     name:       bedrock-prod-data
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -48,4 +48,4 @@ spec:
     kind:       DaemonSet
     name:       bedrock-geoip
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"

--- a/iowa-a/bedrock-stage/vpa.yaml
+++ b/iowa-a/bedrock-stage/vpa.yaml
@@ -22,7 +22,7 @@ spec:
     kind:       Deployment
     name:       bedrock-stage-clock
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -35,4 +35,4 @@ spec:
     kind:       DaemonSet
     name:       bedrock-stage-data
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"

--- a/mozmeao-fr/bedrock-prod/vpa.yaml
+++ b/mozmeao-fr/bedrock-prod/vpa.yaml
@@ -22,7 +22,7 @@ spec:
     kind:       DaemonSet
     name:       bedrock-prod-data
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -35,4 +35,4 @@ spec:
     kind:       DaemonSet
     name:       bedrock-geoip
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Off"


### PR DESCRIPTION
VPAs seems to be thrashing the pods in the cluster, reverting these back to info only.