### PR TITLE
bedrock: Pin ingress-nginx to v0.* to defer Kubernetes upgrade

### DIFF
--- a/mozmeao-fr/bedrock-prod/ingress-controller.sh
+++ b/mozmeao-fr/bedrock-prod/ingress-controller.sh
@@ -3,8 +3,12 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
+# We pin to version ^0 here to exclude ingress-nginx 1.*,
+# which require a Kubernetes upgrade. 20210830 atoll
+
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
+  --version ^0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   bedrock-prod-ingress ingress-nginx/ingress-nginx
 EOM


### PR DESCRIPTION
Bedrock is currently on kubeVersion v1.17.17-eks-087e67, but the ingress-nginx module [v1.0.0 includes a breaking change](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.0.1/Changelog.md#100) that requires kube 1.19.0-0. So this pins our module to v0.*, so that we can keep up on v0 updates (if any) while avoiding the v1+ until our kube catches up.