### PR TITLE
bedrock-fr: Pin ingress-nginx *chart* to 3.36.0 to defer Kubernetes upgrade

### DIFF
--- a/mozmeao-fr/bedrock-prod/ingress-controller.sh
+++ b/mozmeao-fr/bedrock-prod/ingress-controller.sh
@@ -3,12 +3,13 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
-# We pin to version ^0 here to exclude ingress-nginx 1.*,
-# which require a Kubernetes upgrade. 20210830 atoll
+# We pin to helm chart version 3.36.0, which provides appVersion 0.49.0,
+# which is the latest release as of today that doesn't contain app 1.0+
+# with a breaking change to require kubeVersion 1.19+. -- 20210830 atoll
 
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
-  --version ^0 \
+  --version 3.36.0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   bedrock-prod-ingress ingress-nginx/ingress-nginx
 EOM


### PR DESCRIPTION
In #393, I pinned the appVersion rather than [the helm chart version](https://github.com/kubernetes/ingress-nginx/commit/f3c50698d98299b1a61f83cb6c4bb7de0b71fb4b#diff-e72ddd685185c5bc7e7b0a56fc62629956c75d5d3d4a15f2c92c5cd0ba3b0d4eR5). This corrects that.