### PR TITLE
Add a separate frontend-specific Sentry DSN for production ONLY

### DIFF
--- a/iowa-a/bedrock-prod/canary-deploy.yaml
+++ b/iowa-a/bedrock-prod/canary-deploy.yaml
@@ -149,6 +149,8 @@ spec:
               name: bedrock-prod-secrets
         - name: SENTRY_DSN
           value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+        - name: SENTRY_FRONTEND_DSN
+          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
         - name: STATIC_URL
           value: "https://www.mozilla.org/media/"
         - name: STATSD_CLIENT

--- a/iowa-a/bedrock-prod/clock-deploy.yaml
+++ b/iowa-a/bedrock-prod/clock-deploy.yaml
@@ -183,6 +183,8 @@ spec:
               name: bedrock-prod-secrets
         - name: SENTRY_DSN
           value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+        - name: SENTRY_FRONTEND_DSN
+          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
         - name: STATIC_URL
           value: "https://www.mozilla.org/media/"
         - name: STATSD_CLIENT

--- a/iowa-a/bedrock-prod/daemonset.yaml
+++ b/iowa-a/bedrock-prod/daemonset.yaml
@@ -64,6 +64,8 @@ spec:
                 name: bedrock-prod-secrets
           - name: SENTRY_DSN
             value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+          - name: SENTRY_FRONTEND_DSN
+            value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
           - name: STATSD_CLIENT
             value: django_statsd.clients.normal
         resources:

--- a/iowa-a/bedrock-prod/deploy.yaml
+++ b/iowa-a/bedrock-prod/deploy.yaml
@@ -152,6 +152,8 @@ spec:
               name: bedrock-prod-secrets
         - name: SENTRY_DSN
           value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+        - name: SENTRY_FRONTEND_DSN
+          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
         - name: STATIC_URL
           value: "https://www.mozilla.org/media/"
         - name: STATSD_CLIENT

--- a/mozmeao-fr/bedrock-prod/canary-deploy.yaml
+++ b/mozmeao-fr/bedrock-prod/canary-deploy.yaml
@@ -144,6 +144,8 @@ spec:
               name: bedrock-prod-secrets
         - name: SENTRY_DSN
           value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+        - name: SENTRY_FRONTEND_DSN
+          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
         - name: STATIC_URL
           value: "https://www.mozilla.org/media/"
         - name: STATSD_CLIENT

--- a/mozmeao-fr/bedrock-prod/daemonset.yaml
+++ b/mozmeao-fr/bedrock-prod/daemonset.yaml
@@ -64,6 +64,8 @@ spec:
                 name: bedrock-prod-secrets
           - name: SENTRY_DSN
             value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+          - name: SENTRY_FRONTEND_DSN
+            value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
           - name: STATSD_CLIENT
             value: django_statsd.clients.normal
         resources:

--- a/mozmeao-fr/bedrock-prod/deploy.yaml
+++ b/mozmeao-fr/bedrock-prod/deploy.yaml
@@ -146,6 +146,8 @@ spec:
               name: bedrock-prod-secrets
         - name: SENTRY_DSN
           value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
+        - name: SENTRY_FRONTEND_DSN
+          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
         - name: STATIC_URL
           value: "https://www.mozilla.org/media/"
         - name: STATSD_CLIENT


### PR DESCRIPTION
This changeset complements work done in https://github.com/mozilla/bedrock/pull/10727

We're making a frontend-specific Sentry DSN available only in production. 

If it's not available, bedrock site will fall back to the current behaviour of using the same DSN for FE and BE error-logging

Part of work towards [#10593](https://github.com/mozilla/bedrock/issues/10593)