### PR TITLE
Add env vars for new DMS to ping after run-db-update.sh

### DIFF
--- a/iowa-a/bedrock-dev/clock-deploy.yaml
+++ b/iowa-a/bedrock-dev/clock-deploy.yaml
@@ -90,6 +90,11 @@ spec:
               key: CLUSTER_NAME
         - name: CSP_REPORT_ENABLE
           value: "True"
+        - name: DB_UPDATE_SCRIPT_DMS_URL
+          valueFrom:
+            secretKeyRef:
+              key: dead-mans-snitch-db-updates-url
+              name: bedrock-dev-secrets
         - name: DEBUG
           value: "False"
         - name: DEIS_DOMAIN

--- a/iowa-a/bedrock-prod/clock-deploy.yaml
+++ b/iowa-a/bedrock-prod/clock-deploy.yaml
@@ -80,6 +80,11 @@ spec:
             secretKeyRef:
               key: dead-mans-snitch-url
               name: bedrock-prod-secrets
+        - name: DB_UPDATE_SCRIPT_DMS_URL
+          valueFrom:
+            secretKeyRef:
+              key: dead-mans-snitch-db-updates-url
+              name: bedrock-prod-secrets
         - name: DEBUG
           value: "False"
         - name: DEIS_DOMAIN

--- a/iowa-a/bedrock-stage/clock-deploy.yaml
+++ b/iowa-a/bedrock-stage/clock-deploy.yaml
@@ -77,6 +77,11 @@ spec:
           value: "*.allizom.org"
         - name: CSP_REPORT_ENABLE
           value: "False"
+        - name: DB_UPDATE_SCRIPT_DMS_URL
+          valueFrom:
+            secretKeyRef:
+              key: dead-mans-snitch-db-updates-url
+              name: bedrock-stage-secrets
         - name: DEBUG
           value: "False"
         - name: DEIS_DOMAIN


### PR DESCRIPTION
As part of https://github.com/mozilla/bedrock/issues/10814 we're adding one new type of snitch, which is called after Bedrock's DB updater script has been run. 

The new snitch URLs for dev, stage and prod have already been set up (in pause mode) and have been added to the secrets store, so this changeset references them to be pulled in as env vars.