### PR TITLE
Add SQS/Contentful env vars for Stage and Prod, pulling from secrets

### DIFF
--- a/iowa-a/bedrock-prod/clock-deploy.yaml
+++ b/iowa-a/bedrock-prod/clock-deploy.yaml
@@ -63,6 +63,23 @@ spec:
               key: CLUSTER_NAME
         - name: CONTENT_CARDS_BRANCH
           value: prod-processed
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-access-key-id
+              name: bedrock-prod-secrets
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_REGION
+          value: us-west-2
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-secret-access-key
+              name: bedrock-prod-secrets
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_URL
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-queue-url
+              name: bedrock-prod-secrets
         - name: CONTENTFUL_SPACE_ID
           valueFrom:
             secretKeyRef:

--- a/iowa-a/bedrock-stage/clock-deploy.yaml
+++ b/iowa-a/bedrock-stage/clock-deploy.yaml
@@ -63,6 +63,23 @@ spec:
               key: CLUSTER_NAME
         - name: CONTENT_CARDS_BRANCH
           value: master-processed
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-access-key-id
+              name: bedrock-stage-secrets
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_REGION
+          value: us-west-2
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-secret-access-key
+              name: bedrock-stage-secrets
+        - name: CONTENTFUL_NOTIFICATION_QUEUE_URL
+          valueFrom:
+            secretKeyRef:
+              key: contentful-notification-queue-url
+              name: bedrock-stage-secrets
         - name: CONTENTFUL_SPACE_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This changeset draws on secrets already added to the secret store to make them available to bedrock as env vars.

The env vars are already in use on Dev, and the Stage and Prod config updates are copy-paste-edits of the same setup, so there should be no problems.

After this has merged (no rush), we can deploy stage first and see that the queue is being used over the clock-based direct polling, and then roll out to prod.

@pmac if you would prefer this to be two PRs - one for stage and a later one for prod - because the plan above would be harder to roll back, I'm happy to refactor

Resolves https://github.com/mozilla/bedrock/issues/10773