### PR TITLE
Update Sentry DSNs for Bedrock prod + whitespace/autoformat fixup

### DIFF
--- a/iowa-a/bedrock-prod/clock-deploy.yaml
+++ b/iowa-a/bedrock-prod/clock-deploy.yaml
@@ -29,237 +29,237 @@ spec:
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
-      - args:
-        - ./bin/run-db-clock.sh
-        command:
-        - /bin/bash
-        - -c
-        env:
-        - name: ALLOWED_HOSTS
-          value: "*"
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: aws-access-key-id
-              name: bedrock-prod-secrets
-        - name: AWS_DB_S3_BUCKET
-          value: bedrock-db-prod
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws-secret-access-key
-              name: bedrock-prod-secrets
-        - name: BASKET_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: basket-api-key
-              name: bedrock-prod-secrets
-        - name: BASKET_URL
-          value: https://basket.mozilla.org
-        - name: CLUSTER_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: CLUSTER_NAME
-        - name: CONTENT_CARDS_BRANCH
-          value: prod-processed
-        - name: CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: contentful-notification-access-key-id
-              name: bedrock-prod-secrets
-        - name: CONTENTFUL_NOTIFICATION_QUEUE_REGION
-          value: us-west-2
-        - name: CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: contentful-notification-secret-access-key
-              name: bedrock-prod-secrets
-        - name: CONTENTFUL_NOTIFICATION_QUEUE_URL
-          valueFrom:
-            secretKeyRef:
-              key: contentful-notification-queue-url
-              name: bedrock-prod-secrets
-        - name: CONTENTFUL_SPACE_ID
-          valueFrom:
-            secretKeyRef:
-              key: contentful-space-id
-              name: bedrock-prod-secrets
-        - name: CONTENTFUL_SPACE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: contentful-space-key
-              name: bedrock-prod-secrets
-        - name: CSP_REPORT_ENABLE
-          value: "False"
-        - name: DEAD_MANS_SNITCH_URL
-          valueFrom:
-            secretKeyRef:
-              key: dead-mans-snitch-url
-              name: bedrock-prod-secrets
-        - name: DB_UPDATE_SCRIPT_DMS_URL
-          valueFrom:
-            secretKeyRef:
-              key: dead-mans-snitch-db-updates-url
-              name: bedrock-prod-secrets
-        - name: DEBUG
-          value: "False"
-        - name: DEIS_DOMAIN
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: DEIS_DOMAIN
-        - name: DEV
-          value: "False"
-        - name: DISABLE_SSL
-          value: "False"
-        - name: EMAIL_HOST
-          valueFrom:
-            secretKeyRef:
-              key: email-host
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: email-host-password
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_USER
-          valueFrom:
-            secretKeyRef:
-              key: email-host-user
-              name: bedrock-prod-secrets
-        - name: EMAIL_PORT
-          valueFrom:
-            secretKeyRef:
-              key: email-port
-              name: bedrock-prod-secrets
-        - name: EMAIL_USE_TLS
-          valueFrom:
-            secretKeyRef:
-              key: email-use-tls
-              name: bedrock-prod-secrets
-        - name: ENABLE_CSP_MIDDLEWARE
-          value: "True"
-        - name: ENABLE_HOSTNAME_MIDDLEWARE
-          value: "True"
-        - name: FXA_OAUTH_CLIENT_ID
-          value: "40dd9c0253db092c"
-        - name: FXA_OAUTH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: fxa-oauth-client-secret
-              name: bedrock-prod-secrets
-        - name: GTM_CONTAINER_ID
-          value: GTM-MW3R8V
-        - name: HTTPS
-          value: "on"
-        - name: L10N_CRON
-          value: "True"
-        - name: LEGAL_DOCS_DMS_URL
-          valueFrom:
-            secretKeyRef:
-              key: legal-docs-dms-url
-              name: bedrock-prod-secrets
-        - name: LOGLEVEL
-          value: info
-        - name: MOFO_SECURITY_ADVISORIES_PATH
-          value: /tmp/mofo_security_advisories
-        - name: NEWRELIC_PYTHON_INI_FILE
-          value: newrelic.ini
-        - name: NEW_RELIC_APP_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: NEW_RELIC_APP_NAME
-        - name: NEW_RELIC_LICENSE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: new-relic-license-key
-              name: bedrock-prod-secrets
-        - name: POCKET_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: pocket-access-token
-              name: bedrock-prod-secrets
-        - name: POCKET_CONSUMER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: pocket-consumer-key
-              name: bedrock-prod-secrets
-        - name: PROD
-          value: "True"
-        - name: RUN_SUPERVISOR
-          value: "True"
-        - name: SECURE_BROWSER_XSS_FILTER
-          value: "True"
-        - name: SECURE_HSTS_SECONDS
-          value: "31536000"
-        - name: SECURE_SSL_REDIRECT
-          value: "True"
-        - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
-          value: "False"
-        - name: SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secret-key
-              name: bedrock-prod-secrets
-        - name: SENTRY_DSN
-          value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
-        - name: SENTRY_FRONTEND_DSN
-          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
-        - name: STATIC_URL
-          value: "https://www.mozilla.org/media/"
-        - name: STATSD_CLIENT
-          value: django_statsd.clients.normal
-        - name: STD_SMS_COUNTRIES_DESKTOP
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW50
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW61
-          value: US,DE
-        - name: STUB_ATTRIBUTION_HMAC_KEY
-          valueFrom:
-            secretKeyRef:
-              key: stub-attribution-hmac-key
-              name: bedrock-prod-secrets
-        - name: STUB_ATTRIBUTION_RATE
-          value: '1'
-        - name: SWITCH_TRACKING_PIXEL
-          value: 'on'
-        - name: TWITTER_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token
-              name: bedrock-prod-secrets
-        - name: TWITTER_ACCESS_TOKEN_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token-secret
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-key
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-secret
-              name: bedrock-prod-secrets
-        - name: WEB_CONCURRENCY
-          value: "6"
-        image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
-        imagePullPolicy: IfNotPresent
-        name: bedrock-prod-clock
-        resources:
-          limits:
-            cpu: 500m
-            memory: 300Mi
-          requests:
-            cpu: 250m
-            memory: 120Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        - args:
+            - ./bin/run-db-clock.sh
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: ALLOWED_HOSTS
+              value: "*"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws-access-key-id
+                  name: bedrock-prod-secrets
+            - name: AWS_DB_S3_BUCKET
+              value: bedrock-db-prod
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws-secret-access-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: basket-api-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_URL
+              value: https://basket.mozilla.org
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: CLUSTER_NAME
+            - name: CONTENT_CARDS_BRANCH
+              value: prod-processed
+            - name: CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: contentful-notification-access-key-id
+                  name: bedrock-prod-secrets
+            - name: CONTENTFUL_NOTIFICATION_QUEUE_REGION
+              value: us-west-2
+            - name: CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: contentful-notification-secret-access-key
+                  name: bedrock-prod-secrets
+            - name: CONTENTFUL_NOTIFICATION_QUEUE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: contentful-notification-queue-url
+                  name: bedrock-prod-secrets
+            - name: CONTENTFUL_SPACE_ID
+              valueFrom:
+                secretKeyRef:
+                  key: contentful-space-id
+                  name: bedrock-prod-secrets
+            - name: CONTENTFUL_SPACE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: contentful-space-key
+                  name: bedrock-prod-secrets
+            - name: CSP_REPORT_ENABLE
+              value: "False"
+            - name: DEAD_MANS_SNITCH_URL
+              valueFrom:
+                secretKeyRef:
+                  key: dead-mans-snitch-url
+                  name: bedrock-prod-secrets
+            - name: DB_UPDATE_SCRIPT_DMS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: dead-mans-snitch-db-updates-url
+                  name: bedrock-prod-secrets
+            - name: DEBUG
+              value: "False"
+            - name: DEIS_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: DEIS_DOMAIN
+            - name: DEV
+              value: "False"
+            - name: DISABLE_SSL
+              value: "False"
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: email-host
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-password
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_USER
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-user
+                  name: bedrock-prod-secrets
+            - name: EMAIL_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: email-port
+                  name: bedrock-prod-secrets
+            - name: EMAIL_USE_TLS
+              valueFrom:
+                secretKeyRef:
+                  key: email-use-tls
+                  name: bedrock-prod-secrets
+            - name: ENABLE_CSP_MIDDLEWARE
+              value: "True"
+            - name: ENABLE_HOSTNAME_MIDDLEWARE
+              value: "True"
+            - name: FXA_OAUTH_CLIENT_ID
+              value: "40dd9c0253db092c"
+            - name: FXA_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: fxa-oauth-client-secret
+                  name: bedrock-prod-secrets
+            - name: GTM_CONTAINER_ID
+              value: GTM-MW3R8V
+            - name: HTTPS
+              value: "on"
+            - name: L10N_CRON
+              value: "True"
+            - name: LEGAL_DOCS_DMS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: legal-docs-dms-url
+                  name: bedrock-prod-secrets
+            - name: LOGLEVEL
+              value: info
+            - name: MOFO_SECURITY_ADVISORIES_PATH
+              value: /tmp/mofo_security_advisories
+            - name: NEWRELIC_PYTHON_INI_FILE
+              value: newrelic.ini
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: new-relic-license-key
+                  name: bedrock-prod-secrets
+            - name: POCKET_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: pocket-access-token
+                  name: bedrock-prod-secrets
+            - name: POCKET_CONSUMER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: pocket-consumer-key
+                  name: bedrock-prod-secrets
+            - name: PROD
+              value: "True"
+            - name: RUN_SUPERVISOR
+              value: "True"
+            - name: SECURE_BROWSER_XSS_FILTER
+              value: "True"
+            - name: SECURE_HSTS_SECONDS
+              value: "31536000"
+            - name: SECURE_SSL_REDIRECT
+              value: "True"
+            - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
+              value: "False"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: bedrock-prod-secrets
+            - name: SENTRY_DSN
+              value: "https://45ad5d426da7480081831c053ca02cac@o1069899.ingest.sentry.io/6249535"
+            - name: SENTRY_FRONTEND_DSN
+              value: "https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331"
+            - name: STATIC_URL
+              value: "https://www.mozilla.org/media/"
+            - name: STATSD_CLIENT
+              value: django_statsd.clients.normal
+            - name: STD_SMS_COUNTRIES_DESKTOP
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW50
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW61
+              value: US,DE
+            - name: STUB_ATTRIBUTION_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: stub-attribution-hmac-key
+                  name: bedrock-prod-secrets
+            - name: STUB_ATTRIBUTION_RATE
+              value: "1"
+            - name: SWITCH_TRACKING_PIXEL
+              value: "on"
+            - name: TWITTER_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token
+                  name: bedrock-prod-secrets
+            - name: TWITTER_ACCESS_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token-secret
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-key
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-secret
+                  name: bedrock-prod-secrets
+            - name: WEB_CONCURRENCY
+              value: "6"
+          image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
+          imagePullPolicy: IfNotPresent
+          name: bedrock-prod-clock
+          resources:
+            limits:
+              cpu: 500m
+              memory: 300Mi
+            requests:
+              cpu: 250m
+              memory: 120Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/iowa-a/bedrock-prod/daemonset.yaml
+++ b/iowa-a/bedrock-prod/daemonset.yaml
@@ -21,63 +21,63 @@ spec:
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
-      - name: bedrock-prod-data
-        image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
-        imagePullPolicy: IfNotPresent
-        args:
-          - ./bin/run-file-clock.sh
-        command:
-          - /bin/bash
-          - -c
-        env:
-          - name: AWS_DB_S3_BUCKET
-            value: bedrock-db-prod
-          - name: CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: bedrock-prod-configmap
-                key: CLUSTER_NAME
-          - name: DB_DOWNLOAD_IGNORE_GIT
-            value: "False"
-          - name: DEBUG
-            value: "False"
-          - name: DEV
-            value: "False"
-          - name: LOGLEVEL
-            value: info
-          - name: NEW_RELIC_APP_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: bedrock-prod-configmap
-                key: NEW_RELIC_APP_NAME
-          - name: NEW_RELIC_LICENSE_KEY
-            valueFrom:
-              secretKeyRef:
-                key: new-relic-license-key
-                name: bedrock-prod-secrets
-          - name: PROD
-            value: "True"
-          - name: SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                key: secret-key
-                name: bedrock-prod-secrets
-          - name: SENTRY_DSN
-            value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
-          - name: SENTRY_FRONTEND_DSN
-            value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
-          - name: STATSD_CLIENT
-            value: django_statsd.clients.normal
-        resources:
-          limits:
-            cpu: 350m
-            memory: 250Mi
-          requests:
-            cpu: 200m
-            memory: 150Mi
-        volumeMounts:
-        - name: data
-          mountPath: /app/data
+        - name: bedrock-prod-data
+          image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
+          imagePullPolicy: IfNotPresent
+          args:
+            - ./bin/run-file-clock.sh
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: AWS_DB_S3_BUCKET
+              value: bedrock-db-prod
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: CLUSTER_NAME
+            - name: DB_DOWNLOAD_IGNORE_GIT
+              value: "False"
+            - name: DEBUG
+              value: "False"
+            - name: DEV
+              value: "False"
+            - name: LOGLEVEL
+              value: info
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: new-relic-license-key
+                  name: bedrock-prod-secrets
+            - name: PROD
+              value: "True"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: bedrock-prod-secrets
+            - name: SENTRY_DSN
+              value: "https://45ad5d426da7480081831c053ca02cac@o1069899.ingest.sentry.io/6249535"
+            - name: SENTRY_FRONTEND_DSN
+              value: "https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331"
+            - name: STATSD_CLIENT
+              value: django_statsd.clients.normal
+          resources:
+            limits:
+              cpu: 350m
+              memory: 250Mi
+            requests:
+              cpu: 200m
+              memory: 150Mi
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
       priorityClassName: high-priority-preempting
       terminationGracePeriodSeconds: 30
       securityContext:
@@ -85,6 +85,6 @@ spec:
         runAsGroup: 0
         fsGroup: 0
       volumes:
-      - name: data
-        hostPath:
-          path: /var/lib/bedrock-prod/data
+        - name: data
+          hostPath:
+            path: /var/lib/bedrock-prod/data

--- a/iowa-a/bedrock-prod/deploy.yaml
+++ b/iowa-a/bedrock-prod/deploy.yaml
@@ -30,209 +30,209 @@ spec:
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
-      - args:
-        - ./bin/run-prod.sh
-        command:
-        - /bin/bash
-        - -c
-        env:
-        - name: ALLOWED_HOSTS
-          value: "*"
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: aws-access-key-id
-              name: bedrock-prod-secrets
-        - name: AWS_DB_S3_BUCKET
-          value: bedrock-db-prod
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws-secret-access-key
-              name: bedrock-prod-secrets
-        - name: BASKET_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: basket-api-key
-              name: bedrock-prod-secrets
-        - name: BASKET_URL
-          value: https://basket.mozilla.org
-        - name: CLUSTER_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: CLUSTER_NAME
-        - name: CONTENT_CARDS_BRANCH
-          value: prod-processed
-        - name: CSP_REPORT_ENABLE
-          value: "False"
-        - name: DEBUG
-          value: "False"
-        - name: DEIS_DOMAIN
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: DEIS_DOMAIN
-        - name: DEV
-          value: "False"
-        - name: DISABLE_SSL
-          value: "False"
-        - name: EMAIL_HOST
-          valueFrom:
-            secretKeyRef:
-              key: email-host
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: email-host-password
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_USER
-          valueFrom:
-            secretKeyRef:
-              key: email-host-user
-              name: bedrock-prod-secrets
-        - name: EMAIL_PORT
-          valueFrom:
-            secretKeyRef:
-              key: email-port
-              name: bedrock-prod-secrets
-        - name: EMAIL_USE_TLS
-          valueFrom:
-            secretKeyRef:
-              key: email-use-tls
-              name: bedrock-prod-secrets
-        - name: ENABLE_CSP_MIDDLEWARE
-          value: "True"
-        - name: ENABLE_HOSTNAME_MIDDLEWARE
-          value: "True"
-        - name: FXA_OAUTH_CLIENT_ID
-          value: "40dd9c0253db092c"
-        - name: FXA_OAUTH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: fxa-oauth-client-secret
-              name: bedrock-prod-secrets
-        - name: GTM_CONTAINER_ID
-          value: GTM-MW3R8V
-        - name: HTTPS
-          value: "on"
-        - name: L10N_CRON
-          value: "True"
-        - name: LOGLEVEL
-          value: info
-        - name: MOFO_SECURITY_ADVISORIES_PATH
-          value: /tmp/mofo_security_advisories
-        - name: NEWRELIC_PYTHON_INI_FILE
-          value: newrelic.ini
-        - name: NEW_RELIC_APP_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: NEW_RELIC_APP_NAME
-        - name: NEW_RELIC_LICENSE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: new-relic-license-key
-              name: bedrock-prod-secrets
-        - name: PROD
-          value: "True"
-        - name: SECURE_BROWSER_XSS_FILTER
-          value: "True"
-        - name: SECURE_HSTS_SECONDS
-          value: "31536000"
-        - name: SECURE_SSL_REDIRECT
-          value: "True"
-        - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
-          value: "False"
-        - name: SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secret-key
-              name: bedrock-prod-secrets
-        - name: SENTRY_DSN
-          value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
-        - name: SENTRY_FRONTEND_DSN
-          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
-        - name: STATIC_URL
-          value: "https://www.mozilla.org/media/"
-        - name: STATSD_CLIENT
-          value: django_statsd.clients.normal
-        - name: STD_SMS_COUNTRIES_DESKTOP
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW50
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW61
-          value: US,DE
-        - name: STUB_ATTRIBUTION_HMAC_KEY
-          valueFrom:
-            secretKeyRef:
-              key: stub-attribution-hmac-key
-              name: bedrock-prod-secrets
-        - name: STUB_ATTRIBUTION_RATE
-          value: '1'
-        - name: SWITCH_TRACKING_PIXEL
-          value: 'on'
-        - name: TWITTER_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token
-              name: bedrock-prod-secrets
-        - name: TWITTER_ACCESS_TOKEN_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token-secret
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-key
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-secret
-              name: bedrock-prod-secrets
-        - name: WEB_CONCURRENCY
-          value: "6"
-        image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
-        imagePullPolicy: IfNotPresent
-        name: bedrock-prod-web
-        ports:
-          - containerPort: 8000
-        livenessProbe:
-          failureThreshold: 4
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 5
-          httpGet:
-            path: /healthz/
-            scheme: HTTP
-            port: 8000
-        readinessProbe:
-          failureThreshold: 1
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 5
-          httpGet:
-            path: /readiness/
-            scheme: HTTP
-            port: 8000
-        resources:
-          limits:
-            cpu: 1250m
-            memory: 800Mi
-          requests:
-            cpu: 1000m
-            memory: 600Mi
-        volumeMounts:
-          - name: data
-            mountPath: /app/data
-            readOnly: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        - args:
+            - ./bin/run-prod.sh
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: ALLOWED_HOSTS
+              value: "*"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws-access-key-id
+                  name: bedrock-prod-secrets
+            - name: AWS_DB_S3_BUCKET
+              value: bedrock-db-prod
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws-secret-access-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: basket-api-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_URL
+              value: https://basket.mozilla.org
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: CLUSTER_NAME
+            - name: CONTENT_CARDS_BRANCH
+              value: prod-processed
+            - name: CSP_REPORT_ENABLE
+              value: "False"
+            - name: DEBUG
+              value: "False"
+            - name: DEIS_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: DEIS_DOMAIN
+            - name: DEV
+              value: "False"
+            - name: DISABLE_SSL
+              value: "False"
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: email-host
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-password
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_USER
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-user
+                  name: bedrock-prod-secrets
+            - name: EMAIL_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: email-port
+                  name: bedrock-prod-secrets
+            - name: EMAIL_USE_TLS
+              valueFrom:
+                secretKeyRef:
+                  key: email-use-tls
+                  name: bedrock-prod-secrets
+            - name: ENABLE_CSP_MIDDLEWARE
+              value: "True"
+            - name: ENABLE_HOSTNAME_MIDDLEWARE
+              value: "True"
+            - name: FXA_OAUTH_CLIENT_ID
+              value: "40dd9c0253db092c"
+            - name: FXA_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: fxa-oauth-client-secret
+                  name: bedrock-prod-secrets
+            - name: GTM_CONTAINER_ID
+              value: GTM-MW3R8V
+            - name: HTTPS
+              value: "on"
+            - name: L10N_CRON
+              value: "True"
+            - name: LOGLEVEL
+              value: info
+            - name: MOFO_SECURITY_ADVISORIES_PATH
+              value: /tmp/mofo_security_advisories
+            - name: NEWRELIC_PYTHON_INI_FILE
+              value: newrelic.ini
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: new-relic-license-key
+                  name: bedrock-prod-secrets
+            - name: PROD
+              value: "True"
+            - name: SECURE_BROWSER_XSS_FILTER
+              value: "True"
+            - name: SECURE_HSTS_SECONDS
+              value: "31536000"
+            - name: SECURE_SSL_REDIRECT
+              value: "True"
+            - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
+              value: "False"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: bedrock-prod-secrets
+            - name: SENTRY_DSN
+              value: "https://45ad5d426da7480081831c053ca02cac@o1069899.ingest.sentry.io/6249535"
+            - name: SENTRY_FRONTEND_DSN
+              value: "https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331"
+            - name: STATIC_URL
+              value: "https://www.mozilla.org/media/"
+            - name: STATSD_CLIENT
+              value: django_statsd.clients.normal
+            - name: STD_SMS_COUNTRIES_DESKTOP
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW50
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW61
+              value: US,DE
+            - name: STUB_ATTRIBUTION_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: stub-attribution-hmac-key
+                  name: bedrock-prod-secrets
+            - name: STUB_ATTRIBUTION_RATE
+              value: "1"
+            - name: SWITCH_TRACKING_PIXEL
+              value: "on"
+            - name: TWITTER_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token
+                  name: bedrock-prod-secrets
+            - name: TWITTER_ACCESS_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token-secret
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-key
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-secret
+                  name: bedrock-prod-secrets
+            - name: WEB_CONCURRENCY
+              value: "6"
+          image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
+          imagePullPolicy: IfNotPresent
+          name: bedrock-prod-web
+          ports:
+            - containerPort: 8000
+          livenessProbe:
+            failureThreshold: 4
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /healthz/
+              scheme: HTTP
+              port: 8000
+          readinessProbe:
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /readiness/
+              scheme: HTTP
+              port: 8000
+          resources:
+            limits:
+              cpu: 1250m
+              memory: 800Mi
+            requests:
+              cpu: 1000m
+              memory: 600Mi
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+              readOnly: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/mozmeao-fr/bedrock-prod/daemonset.yaml
+++ b/mozmeao-fr/bedrock-prod/daemonset.yaml
@@ -21,63 +21,63 @@ spec:
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
-      - name: bedrock-prod-data
-        image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
-        imagePullPolicy: IfNotPresent
-        args:
-          - ./bin/run-file-clock.sh
-        command:
-          - /bin/bash
-          - -c
-        env:
-          - name: AWS_DB_S3_BUCKET
-            value: bedrock-db-prod
-          - name: CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: bedrock-prod-configmap
-                key: CLUSTER_NAME
-          - name: DB_DOWNLOAD_IGNORE_GIT
-            value: "False"
-          - name: DEBUG
-            value: "False"
-          - name: DEV
-            value: "False"
-          - name: LOGLEVEL
-            value: info
-          - name: NEW_RELIC_APP_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: bedrock-prod-configmap
-                key: NEW_RELIC_APP_NAME
-          - name: NEW_RELIC_LICENSE_KEY
-            valueFrom:
-              secretKeyRef:
-                key: new-relic-license-key
-                name: bedrock-prod-secrets
-          - name: PROD
-            value: "True"
-          - name: SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                key: secret-key
-                name: bedrock-prod-secrets
-          - name: SENTRY_DSN
-            value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
-          - name: SENTRY_FRONTEND_DSN
-            value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
-          - name: STATSD_CLIENT
-            value: django_statsd.clients.normal
-        resources:
-          limits:
-            cpu: 350m
-            memory: 250Mi
-          requests:
-            cpu: 200m
-            memory: 150Mi
-        volumeMounts:
-        - name: data
-          mountPath: /app/data
+        - name: bedrock-prod-data
+          image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
+          imagePullPolicy: IfNotPresent
+          args:
+            - ./bin/run-file-clock.sh
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: AWS_DB_S3_BUCKET
+              value: bedrock-db-prod
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: CLUSTER_NAME
+            - name: DB_DOWNLOAD_IGNORE_GIT
+              value: "False"
+            - name: DEBUG
+              value: "False"
+            - name: DEV
+              value: "False"
+            - name: LOGLEVEL
+              value: info
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: new-relic-license-key
+                  name: bedrock-prod-secrets
+            - name: PROD
+              value: "True"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: bedrock-prod-secrets
+            - name: SENTRY_DSN
+              value: "https://45ad5d426da7480081831c053ca02cac@o1069899.ingest.sentry.io/6249535"
+            - name: SENTRY_FRONTEND_DSN
+              value: "https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331"
+            - name: STATSD_CLIENT
+              value: django_statsd.clients.normal
+          resources:
+            limits:
+              cpu: 350m
+              memory: 250Mi
+            requests:
+              cpu: 200m
+              memory: 150Mi
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
       priorityClassName: high-priority-preempting
       terminationGracePeriodSeconds: 30
       securityContext:
@@ -85,6 +85,6 @@ spec:
         runAsGroup: 0
         fsGroup: 0
       volumes:
-      - name: data
-        hostPath:
-          path: /var/lib/bedrock-prod/data
+        - name: data
+          hostPath:
+            path: /var/lib/bedrock-prod/data

--- a/mozmeao-fr/bedrock-prod/deploy.yaml
+++ b/mozmeao-fr/bedrock-prod/deploy.yaml
@@ -29,204 +29,204 @@ spec:
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
-      - args:
-        - ./bin/run-prod.sh
-        command:
-        - /bin/bash
-        - -c
-        env:
-        - name: ALLOWED_HOSTS
-          value: "*"
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: aws-access-key-id
-              name: bedrock-prod-secrets
-        - name: AWS_DB_S3_BUCKET
-          value: bedrock-db-prod
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws-secret-access-key
-              name: bedrock-prod-secrets
-        - name: BASKET_API_KEY
-          valueFrom:
-            secretKeyRef:
-              key: basket-api-key
-              name: bedrock-prod-secrets
-        - name: BASKET_URL
-          value: https://basket.mozilla.org
-        - name: CLUSTER_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: CLUSTER_NAME
-        - name: CONTENT_CARDS_BRANCH
-          value: prod-processed
-        - name: CSP_REPORT_ENABLE
-          value: "False"
-        - name: DEBUG
-          value: "False"
-        - name: DEV
-          value: "False"
-        - name: DISABLE_SSL
-          value: "False"
-        - name: EMAIL_HOST
-          valueFrom:
-            secretKeyRef:
-              key: email-host
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: email-host-password
-              name: bedrock-prod-secrets
-        - name: EMAIL_HOST_USER
-          valueFrom:
-            secretKeyRef:
-              key: email-host-user
-              name: bedrock-prod-secrets
-        - name: EMAIL_PORT
-          valueFrom:
-            secretKeyRef:
-              key: email-port
-              name: bedrock-prod-secrets
-        - name: EMAIL_USE_TLS
-          valueFrom:
-            secretKeyRef:
-              key: email-use-tls
-              name: bedrock-prod-secrets
-        - name: ENABLE_CSP_MIDDLEWARE
-          value: "True"
-        - name: ENABLE_HOSTNAME_MIDDLEWARE
-          value: "True"
-        - name: FXA_OAUTH_CLIENT_ID
-          value: "40dd9c0253db092c"
-        - name: FXA_OAUTH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: fxa-oauth-client-secret
-              name: bedrock-prod-secrets
-        - name: GTM_CONTAINER_ID
-          value: GTM-MW3R8V
-        - name: HTTPS
-          value: "on"
-        - name: L10N_CRON
-          value: "True"
-        - name: LOGLEVEL
-          value: info
-        - name: MOFO_SECURITY_ADVISORIES_PATH
-          value: /tmp/mofo_security_advisories
-        - name: NEWRELIC_PYTHON_INI_FILE
-          value: newrelic.ini
-        - name: NEW_RELIC_APP_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: bedrock-prod-configmap
-              key: NEW_RELIC_APP_NAME
-        - name: NEW_RELIC_LICENSE_KEY
-          valueFrom:
-            secretKeyRef:
-              key: new-relic-license-key
-              name: bedrock-prod-secrets
-        - name: PROD
-          value: "True"
-        - name: SECURE_BROWSER_XSS_FILTER
-          value: "True"
-        - name: SECURE_HSTS_SECONDS
-          value: "31536000"
-        - name: SECURE_SSL_REDIRECT
-          value: "True"
-        - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
-          value: "False"
-        - name: SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secret-key
-              name: bedrock-prod-secrets
-        - name: SENTRY_DSN
-          value: "https://dd94e99168c6431899c1daa5a812d8b6@sentry.prod.mozaws.net/152"
-        - name: SENTRY_FRONTEND_DSN
-          value: "https://b59c6af43c5040298ca14d42bed127ab@sentry.prod.mozaws.net/603"
-        - name: STATIC_URL
-          value: "https://www.mozilla.org/media/"
-        - name: STATSD_CLIENT
-          value: django_statsd.clients.normal
-        - name: STD_SMS_COUNTRIES_DESKTOP
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW50
-          value: US,DE,FR
-        - name: STD_SMS_COUNTRIES_WHATSNEW61
-          value: US,DE
-        - name: STUB_ATTRIBUTION_HMAC_KEY
-          valueFrom:
-            secretKeyRef:
-              key: stub-attribution-hmac-key
-              name: bedrock-prod-secrets
-        - name: STUB_ATTRIBUTION_RATE
-          value: '1'
-        - name: SWITCH_TRACKING_PIXEL
-          value: 'on'
-        - name: TWITTER_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token
-              name: bedrock-prod-secrets
-        - name: TWITTER_ACCESS_TOKEN_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-access-token-secret
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-key
-              name: bedrock-prod-secrets
-        - name: TWITTER_CONSUMER_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: twitter-consumer-secret
-              name: bedrock-prod-secrets
-        - name: WEB_CONCURRENCY
-          value: "6"
-        image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
-        imagePullPolicy: IfNotPresent
-        name: bedrock-prod-web
-        ports:
-          - containerPort: 8000
-        livenessProbe:
-          failureThreshold: 4
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 5
-          httpGet:
-            path: /healthz/
-            scheme: HTTP
-            port: 8000
-        readinessProbe:
-          failureThreshold: 1
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 5
-          httpGet:
-            path: /readiness/
-            scheme: HTTP
-            port: 8000
-        resources:
-          limits:
-            cpu: 1500m
-            memory: 1000Mi
-          requests:
-            cpu: 1400m
-            memory: 900Mi
-        volumeMounts:
-          - name: data
-            mountPath: /app/data
-            readOnly: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        - args:
+            - ./bin/run-prod.sh
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: ALLOWED_HOSTS
+              value: "*"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws-access-key-id
+                  name: bedrock-prod-secrets
+            - name: AWS_DB_S3_BUCKET
+              value: bedrock-db-prod
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws-secret-access-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: basket-api-key
+                  name: bedrock-prod-secrets
+            - name: BASKET_URL
+              value: https://basket.mozilla.org
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: CLUSTER_NAME
+            - name: CONTENT_CARDS_BRANCH
+              value: prod-processed
+            - name: CSP_REPORT_ENABLE
+              value: "False"
+            - name: DEBUG
+              value: "False"
+            - name: DEV
+              value: "False"
+            - name: DISABLE_SSL
+              value: "False"
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: email-host
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-password
+                  name: bedrock-prod-secrets
+            - name: EMAIL_HOST_USER
+              valueFrom:
+                secretKeyRef:
+                  key: email-host-user
+                  name: bedrock-prod-secrets
+            - name: EMAIL_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: email-port
+                  name: bedrock-prod-secrets
+            - name: EMAIL_USE_TLS
+              valueFrom:
+                secretKeyRef:
+                  key: email-use-tls
+                  name: bedrock-prod-secrets
+            - name: ENABLE_CSP_MIDDLEWARE
+              value: "True"
+            - name: ENABLE_HOSTNAME_MIDDLEWARE
+              value: "True"
+            - name: FXA_OAUTH_CLIENT_ID
+              value: "40dd9c0253db092c"
+            - name: FXA_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: fxa-oauth-client-secret
+                  name: bedrock-prod-secrets
+            - name: GTM_CONTAINER_ID
+              value: GTM-MW3R8V
+            - name: HTTPS
+              value: "on"
+            - name: L10N_CRON
+              value: "True"
+            - name: LOGLEVEL
+              value: info
+            - name: MOFO_SECURITY_ADVISORIES_PATH
+              value: /tmp/mofo_security_advisories
+            - name: NEWRELIC_PYTHON_INI_FILE
+              value: newrelic.ini
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bedrock-prod-configmap
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: new-relic-license-key
+                  name: bedrock-prod-secrets
+            - name: PROD
+              value: "True"
+            - name: SECURE_BROWSER_XSS_FILTER
+              value: "True"
+            - name: SECURE_HSTS_SECONDS
+              value: "31536000"
+            - name: SECURE_SSL_REDIRECT
+              value: "True"
+            - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE
+              value: "False"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: bedrock-prod-secrets
+            - name: SENTRY_DSN
+              value: "https://45ad5d426da7480081831c053ca02cac@o1069899.ingest.sentry.io/6249535"
+            - name: SENTRY_FRONTEND_DSN
+              value: "https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331"
+            - name: STATIC_URL
+              value: "https://www.mozilla.org/media/"
+            - name: STATSD_CLIENT
+              value: django_statsd.clients.normal
+            - name: STD_SMS_COUNTRIES_DESKTOP
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW50
+              value: US,DE,FR
+            - name: STD_SMS_COUNTRIES_WHATSNEW61
+              value: US,DE
+            - name: STUB_ATTRIBUTION_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: stub-attribution-hmac-key
+                  name: bedrock-prod-secrets
+            - name: STUB_ATTRIBUTION_RATE
+              value: "1"
+            - name: SWITCH_TRACKING_PIXEL
+              value: "on"
+            - name: TWITTER_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token
+                  name: bedrock-prod-secrets
+            - name: TWITTER_ACCESS_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-access-token-secret
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-key
+                  name: bedrock-prod-secrets
+            - name: TWITTER_CONSUMER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: twitter-consumer-secret
+                  name: bedrock-prod-secrets
+            - name: WEB_CONCURRENCY
+              value: "6"
+          image: mozmeao/bedrock:2d4949f9b31d8f8444833ba595fa7f0ef6f9cd3d
+          imagePullPolicy: IfNotPresent
+          name: bedrock-prod-web
+          ports:
+            - containerPort: 8000
+          livenessProbe:
+            failureThreshold: 4
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /healthz/
+              scheme: HTTP
+              port: 8000
+          readinessProbe:
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /readiness/
+              scheme: HTTP
+              port: 8000
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 1000Mi
+            requests:
+              cpu: 1400m
+              memory: 900Mi
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+              readOnly: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
Not to be merged until we're happy the replacement Sentry service is good to go

Apologies, too, for further whitespace shenanigans. They came from my editor running a YAML linter and fixing some nesting. Reviewing without whitespace changes is recommended.