### PR TITLE
Update pocket-mode CSP and static urls to match new CDN domains

### DIFF
--- a/iowa-a/bedrock-dev/pocket-deploy.yaml
+++ b/iowa-a/bedrock-dev/pocket-deploy.yaml
@@ -69,7 +69,7 @@ spec:
                   key: contentful-space-key
                   name: bedrock-dev-secrets
             - name: CSP_DEFAULT_SRC
-              value: "*.allizom.org"
+              value: "dev.tekcopteg.com"
             - name: CSP_REPORT_ENABLE
               value: "True"
             - name: DEBUG
@@ -146,7 +146,7 @@ spec:
             - name: SITE_MODE
               value: "Pocket"
             - name: STATIC_URL
-              value: "https://www-dev.allizom.org/media/"
+              value: "https://dev.tekcopteg.com/media/"
             - name: STATSD_CLIENT
               value: django_statsd.clients.normal
             - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE

--- a/iowa-a/bedrock-stage/pocket-deploy.yaml
+++ b/iowa-a/bedrock-stage/pocket-deploy.yaml
@@ -64,7 +64,7 @@ spec:
             - name: CONTENT_CARDS_BRANCH
               value: master-processed
             - name: CSP_DEFAULT_SRC
-              value: "*.allizom.org"
+              value: "tekcopteg.com"
             - name: CSP_REPORT_ENABLE
               value: "False"
             - name: DEBUG
@@ -157,7 +157,7 @@ spec:
             - name: SITE_MODE
               value: "Pocket"
             - name: STATIC_URL
-              value: "https://www.allizom.org/media/"
+              value: "https://tekcopteg.com/media/"
             - name: STATSD_CLIENT
               value: django_statsd.clients.normal
             - name: STD_SMS_COUNTRIES_DESKTOP

--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -52,7 +52,7 @@ spec:
             - name: CONTENT_CARDS_URL
               value: https://www-dev.allizom.org/media/
             - name: CSP_DEFAULT_SRC
-              value: "*.allizom.org"
+              value: "*.tekcopteg.com"
             - name: CSP_REPORT_ENABLE
               value: "True"
             - name: DB_DOWNLOAD_IGNORE_GIT


### PR DESCRIPTION
We should merge this only after the stage CDN (https://tekcopteg.com) is setup.