### PR TITLE
chore(pocket-test): Point at test domain

### DIFF
--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -111,7 +111,7 @@ spec:
             - name: SITE_MODE
               value: "Pocket"
             - name: STATIC_URL
-              value: "https://bedrock-pocket-test.gcp.moz.works/media/"
+              value: "https://test.tekcopteg.com/media/"
             - name: STATSD_CLIENT
               value: django_statsd.clients.normal
             - name: SWITCH_NEWSLETTER_MAINTENANCE_MODE


### PR DESCRIPTION
Noticed that `test.tekcopteg.com` was not rendering correctly because of CSP to the gcp domain. Updated to point at the test.tekcopteg.com domain.