### PR TITLE
Updates for GA in Pocket Mode + sec bump

### DIFF
--- a/iowa-a/bedrock-dev/pocket-deploy.yaml
+++ b/iowa-a/bedrock-dev/pocket-deploy.yaml
@@ -109,8 +109,6 @@ spec:
               value: "True"
             - name: FXA_ENDPOINT
               value: "https://accounts.stage.mozaws.net/"
-            - name: GTM_CONTAINER_ID
-              value: GTM-MW3R8V
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-dev/pocket-deploy.yaml
+++ b/iowa-a/bedrock-dev/pocket-deploy.yaml
@@ -109,6 +109,8 @@ spec:
               value: "True"
             - name: FXA_ENDPOINT
               value: "https://accounts.stage.mozaws.net/"
+            - name: GOOGLE_ANALYTICS_ID
+              value: "UA-370613-9"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-prod/pocket-deploy.yaml
+++ b/iowa-a/bedrock-prod/pocket-deploy.yaml
@@ -113,8 +113,6 @@ spec:
             secretKeyRef:
               key: fxa-oauth-client-secret
               name: bedrock-prod-secrets
-        - name: GTM_CONTAINER_ID
-          value: GTM-MW3R8V
         - name: HTTPS
           value: "on"
         - name: L10N_CRON

--- a/iowa-a/bedrock-prod/pocket-deploy.yaml
+++ b/iowa-a/bedrock-prod/pocket-deploy.yaml
@@ -113,6 +113,8 @@ spec:
             secretKeyRef:
               key: fxa-oauth-client-secret
               name: bedrock-prod-secrets
+        - name: GOOGLE_ANALYTICS_ID
+          value: "UA-370613-9"
         - name: HTTPS
           value: "on"
         - name: L10N_CRON

--- a/iowa-a/bedrock-stage/pocket-deploy.yaml
+++ b/iowa-a/bedrock-stage/pocket-deploy.yaml
@@ -120,8 +120,6 @@ spec:
                 secretKeyRef:
                   key: fxa-oauth-client-secret
                   name: bedrock-stage-secrets
-            - name: GTM_CONTAINER_ID
-              value: GTM-MW3R8V
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-stage/pocket-deploy.yaml
+++ b/iowa-a/bedrock-stage/pocket-deploy.yaml
@@ -120,6 +120,8 @@ spec:
                 secretKeyRef:
                   key: fxa-oauth-client-secret
                   name: bedrock-stage-secrets
+            - name: GOOGLE_ANALYTICS_ID
+              value: "UA-370613-9"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -72,8 +72,6 @@ spec:
               value: "True"
             - name: ENABLE_HOSTNAME_MIDDLEWARE
               value: "True"
-            - name: GTM_CONTAINER_ID
-              value: GTM-MW3R8V
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -72,6 +72,8 @@ spec:
               value: "True"
             - name: ENABLE_HOSTNAME_MIDDLEWARE
               value: "True"
+            - name: GOOGLE_ANALYTICS_ID
+              value: "UA-370613-9"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-mkdocs==1.0.4
+mkdocs==1.2.3
+jinja2==3.0.3  # Downpin else mkdocs breaks


### PR DESCRIPTION
* Upgrades mkdocs, following security ping by Github. Downside is we have to downpin Jinja2 to ensure docs still build
* Remove redundant GTM ID for Pocket Mode
* Add Google Analytics ID for Pocket Mode (not secret, because it's a GA ID that'll be in the HTML template)