### PR TITLE
Make Stage use pre-production as its Contentful environment

### DIFF
--- a/iowa-a/bedrock-stage/clock-deploy.yaml
+++ b/iowa-a/bedrock-stage/clock-deploy.yaml
@@ -90,6 +90,8 @@ spec:
                 secretKeyRef:
                   key: contentful-space-key
                   name: bedrock-stage-secrets
+            - name: CONTENTFUL_ENVIRONMENT
+              value: "pre-production"
             - name: CSP_DEFAULT_SRC
               value: "*.allizom.org"
             - name: CSP_REPORT_ENABLE


### PR DESCRIPTION
Note that, unlike dev, stage does not preview live content, so only the clock pod has Contentful config