### PR TITLE
Add GTM_CONTAINER_ID for pocket deploy

### DIFF
--- a/iowa-a/bedrock-dev/pocket-deploy.yaml
+++ b/iowa-a/bedrock-dev/pocket-deploy.yaml
@@ -113,6 +113,8 @@ spec:
               value: "https://accounts.stage.mozaws.net/"
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
+            - name: GTM_CONTAINER_ID
+              value: "G-NFR9Y40GD3"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-prod/pocket-deploy.yaml
+++ b/iowa-a/bedrock-prod/pocket-deploy.yaml
@@ -115,6 +115,8 @@ spec:
               name: bedrock-prod-secrets
         - name: GOOGLE_ANALYTICS_ID
           value: "UA-370613-9"
+        - name: GTM_CONTAINER_ID
+          value: "G-NFR9Y40GD3"
         - name: HTTPS
           value: "on"
         - name: L10N_CRON

--- a/iowa-a/bedrock-stage/pocket-deploy.yaml
+++ b/iowa-a/bedrock-stage/pocket-deploy.yaml
@@ -122,6 +122,8 @@ spec:
                   name: bedrock-stage-secrets
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
+            - name: GTM_CONTAINER_ID
+              value: "G-NFR9Y40GD3"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -74,6 +74,8 @@ spec:
               value: "True"
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
+            - name: GTM_CONTAINER_ID
+              value: "G-NFR9Y40GD3"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON


### PR DESCRIPTION
Related to [this](https://github.com/mozilla/bedrock/pull/12433) PR on bedrock. This adds the GTM_CONTAINER_ID for the pocket deploys