### PR TITLE
Update Pocket GTM Container settings

### DIFF
--- a/iowa-a/bedrock-dev/pocket-deploy.yaml
+++ b/iowa-a/bedrock-dev/pocket-deploy.yaml
@@ -114,7 +114,7 @@ spec:
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
             - name: GTM_CONTAINER_ID
-              value: "G-NFR9Y40GD3"
+              value: "GTM-P4LPJ42"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-stage/pocket-deploy.yaml
+++ b/iowa-a/bedrock-stage/pocket-deploy.yaml
@@ -123,7 +123,7 @@ spec:
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
             - name: GTM_CONTAINER_ID
-              value: "G-NFR9Y40GD3"
+              value: "GTM-P4LPJ42"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON

--- a/iowa-a/bedrock-test/pocket-deploy.yaml
+++ b/iowa-a/bedrock-test/pocket-deploy.yaml
@@ -75,7 +75,7 @@ spec:
             - name: GOOGLE_ANALYTICS_ID
               value: "UA-370613-9"
             - name: GTM_CONTAINER_ID
-              value: "G-NFR9Y40GD3"
+              value: "GTM-P4LPJ42"
             - name: HTTPS
               value: "on"
             - name: L10N_CRON


### PR DESCRIPTION
~We should not be running GA4 GTM scripts from any environment other than prod because we do not have views or hostname filter options on the resulting data (as in Universal Analytics).~

We have solved the GA4 filter issue with a [GTM config change](https://github.com/mozilla/bedrock/issues/12630). This PR will update GTM IDs on all environments and does not need to delete any.

related to https://github.com/mozilla/bedrock/pull/12638