### PR TITLE
Update bouncer config to fix Gitlab CI tests that are hitting the new infra 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,7 @@ include:
       - $CI_PIPELINE_SOURCE == "push"
   variables:
     ENVIRONMENT_URL: https://www-dev.allizom.org
+    BOUNCER_URL: https://bouncer-bouncer.stage.mozaws.net/
 
 .dev-iowa:
   extends:

--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -56,6 +56,7 @@ docker run \
     -e "BASE_URL=${BASE_URL:-}" \
     -e "BASE_POCKET_URL=${BASE_POCKET_URL:-}" \
     -e "PYTEST_PROCESSES=${PYTEST_PROCESSES:=4}" \
+    -e "BOUNCER_URL=${BOUNCER_URL:-'https://download.mozilla.org/'}" \
     -e "SCREEN_WIDTH=1600" \
     -e "SCREEN_HEIGHT=1200" \
     ${TEST_IMAGE} bin/run-integration-tests.sh


### PR DESCRIPTION
Add `BOUNCER_URL` for Dev only, so our tests are expecting the same domain for downloads as www-dev is now serving.

www-dev is on new infra, so uses the new config repo, while the tests are using the older conifg (this repo) which had no knowledge of www-dev now using a different,non-default `BOUNCER_URL`