### PR TITLE
Update pocket prod GTM container ID

### DIFF
--- a/iowa-a/bedrock-prod/pocket-deploy.yaml
+++ b/iowa-a/bedrock-prod/pocket-deploy.yaml
@@ -116,7 +116,7 @@ spec:
         - name: GOOGLE_ANALYTICS_ID
           value: "UA-370613-9"
         - name: GTM_CONTAINER_ID
-          value: "G-NFR9Y40GD3"
+          value: "GTM-P4LPJ42"
         - name: HTTPS
           value: "on"
         - name: L10N_CRON


### PR DESCRIPTION
Follow up from https://github.com/mozmeao/www-config/pull/503

Tested from stage and ready to deploy new GTM Container ID in prod

Once in prod, the GTM container should connect to prod GA4 id (starts with `G-RBR`)